### PR TITLE
✏️ Fixes typo in dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,8 @@ install_requires =
     django >= 3.2
     django-choices
     django-privates
-    pyopenssl
-    cryptography
+    pyopenssl >= 22
+    cryptography >= 35
     certifi
 tests_require =
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     django-choices
     django-privates
     pyopenssl
-    cryptograpy
+    cryptography
     certifi
 tests_require =
     pytest


### PR DESCRIPTION
The typo wasn't used anywhere in the code. And code worked because "cryptography" was already an indirect requirement via pyopenssl. The cryptograpy package on pypi is a inoccuous  one that points out you have a typo.