### PR TITLE
[#13] prevent download of private keys

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
 tests_require =
     pytest
     pytest-django
+    pyquery
     tox
     isort
     black
@@ -58,6 +59,7 @@ include =
 tests =
     pytest
     pytest-django
+    pyquery
     tox
     isort
     black

--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -25,6 +25,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
     readonly_fields = ("serial_number",)
 
     private_media_fields = ("public_certificate", "private_key")
+    private_media_no_download_fields = ("private_key",)
 
     @admin.display(description=_("label"), ordering="label")
     def get_label(self, obj):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from django.contrib.admin import AdminSite
+from django.contrib.auth.models import User
+from django.core.files import File
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from privates.test import temp_private_root
+from pyquery import PyQuery as pq
+
+from simple_certmanager.admin import CertificateAdmin
+from simple_certmanager.constants import CertificateTypes
+from simple_certmanager.models import Certificate
+
+TEST_FILES = Path(__file__).parent / "data"
+
+
+@temp_private_root()
+class AdminTests(TestCase):
+    def test_list_view(self):
+        """Assert that certificates are correctly displayed in the list view"""
+
+        with open(TEST_FILES / "test.certificate", "r") as client_certificate_f:
+            certificate = Certificate.objects.create(
+                label="Test certificate",
+                type=CertificateTypes.key_pair,
+                public_certificate=File(client_certificate_f, name="test.certificate"),
+            )
+
+        CertificateAdmin(model=Certificate, admin_site=AdminSite())
+
+        User.objects.create_superuser(username="admin", password="secret")
+        client = Client()
+        client.login(username="admin", password="secret")
+
+        # check response
+        url = reverse("admin:simple_certmanager_certificate_changelist")
+
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        # check that certificate is correctly displayed
+        html = response.content.decode("utf-8")
+        doc = pq(html)
+        fields = doc(".field-get_label")
+        anchor = fields[0].getchildren()[0]
+
+        self.assertEqual(anchor.tag, "a")
+        self.assertEqual(anchor.text, certificate.label)
+
+    def test_detail_view(self):
+        """Assert that public certificates and private keys are correctly displayed in
+        the Admin's change_view, but no download link is present for the private key
+
+        The functionality for the private key is implemented and tested in django-
+        privates, but we need to make sure that `private_media_no_download_fields` has
+        actually been set in this library."""
+
+        with open(TEST_FILES / "test.certificate", "r") as client_certificate_f, open(
+            TEST_FILES / "test.key", "r"
+        ) as key_f:
+            certificate = Certificate.objects.create(
+                label="Test certificate",
+                type=CertificateTypes.key_pair,
+                public_certificate=File(client_certificate_f, name="test.certificate"),
+                private_key=File(key_f, name="test.key"),
+            )
+
+        CertificateAdmin(model=Certificate, admin_site=AdminSite())
+
+        User.objects.create_superuser(username="admin", password="secret")
+        client = Client()
+        client.login(username="admin", password="secret")
+
+        # check response
+        url = reverse(
+            "admin:simple_certmanager_certificate_change", args=(certificate.pk,)
+        )
+
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        # parse content
+        html = response.content.decode("utf-8")
+        doc = pq(html)
+        uploads = doc(".file-upload")
+
+        # check that public certificate is correctly displayed with link
+        anchor = uploads.children()[0]
+
+        self.assertEqual(anchor.tag, "a")
+        self.assertEqual(anchor.text, certificate.public_certificate.name)
+
+        # check that private key is correctly displayed without link
+        pk = uploads[1]
+
+        display_value = pk.text.strip()
+
+        self.assertEqual(pk.tag, "p")
+        self.assertEqual(
+            display_value, _("Currently: %s") % certificate.private_key.name
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ extras =
     coverage
 deps =
   django32: Django~=3.2.0
+  pyquery==2.0.0
 commands =
   py.test tests \
    --junitxml=reports/junit.xml \


### PR DESCRIPTION
Fixes #13 (partly)

- complements the security patch to django-privates [(PR #5)](https://github.com/sergei-maertens/django-privates/pull/5/) by overriding the `private_media_no_download_fields` attribute in the admin
- adds tests for the admin's list and detail views and checks that the latter does not contain a download link for private keys