### PR TITLE
Add type checking to CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ tests_require =
     black
     flake8
     freezegun
+    django-stubs[compatible-mypy]
 
 [options.packages.find]
 include =
@@ -66,6 +67,7 @@ tests =
     black
     flake8
     freezegun
+    django-stubs[compatible-mypy]
 pep8 = flake8
 coverage = pytest-cov
 docs =
@@ -96,3 +98,10 @@ DJANGO_SETTINGS_MODULE=testapp.settings
 max-line-length=88
 exclude=env,.tox,doc
 ignore=E203,W503
+
+[mypy]
+plugins =
+    mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "testapp.settings"

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,3 +105,7 @@ plugins =
 
 [mypy.plugins.django-stubs]
 django_settings_module = "testapp.settings"
+
+[mypy-factory]
+# typing support for factory-boy *is* coming
+ignore_missing_imports = True

--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -10,6 +10,7 @@ from .utils import suppress_cryptography_errors
 
 @admin.register(Certificate)
 class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
+    model: type[Certificate]
     form = CertificateAdminForm
 
     fields = ("label", "serial_number", "type", "public_certificate", "private_key")

--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -29,7 +29,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
     private_media_no_download_fields = ("private_key",)
 
     @admin.display(description=_("label"), ordering="label")
-    def get_label(self, obj):
+    def get_label(self, obj) -> str:
         return str(obj)
 
     @admin.display(description=_("serial number"))
@@ -52,7 +52,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
 
     @admin.display(description=_("valid key pair"), boolean=True)
     @suppress_cryptography_errors
-    def is_valid_key_pair(self, obj: Certificate):
+    def is_valid_key_pair(self, obj: Certificate) -> bool | None:
         # alias model property to catch errors
         try:
             return obj.is_valid_key_pair()

--- a/simple_certmanager/mixins.py
+++ b/simple_certmanager/mixins.py
@@ -70,7 +70,9 @@ class DeleteFileFieldFilesMixin:
         file_field_names = get_file_field_names(type(self))  # type: ignore
         with transaction.atomic():
             result = super().delete(*args, **kwargs)  # type: ignore
-            transaction.on_commit(lambda: _delete_obj_files(file_field_names, self))  # type: ignore
+            transaction.on_commit(
+                lambda: _delete_obj_files(file_field_names, self)  # type: ignore
+            )
         return result
 
     delete.alters_data = True  # type: ignore

--- a/simple_certmanager/mixins.py
+++ b/simple_certmanager/mixins.py
@@ -48,7 +48,7 @@ class log_failed_deletes:
             return True
 
 
-def _delete_obj_files(fields: List[str], obj: models.Model) -> None:
+def _delete_obj_files(fields: list[str], obj: models.Model) -> None:
     for name in fields:
         filefield = getattr(obj, name)
         with log_failed_deletes(filefield):

--- a/simple_certmanager/mixins.py
+++ b/simple_certmanager/mixins.py
@@ -4,16 +4,14 @@ These utilities apply to file fields and subclasses thereof.
 """
 
 import logging
-from typing import List
 
 from django.db import models, transaction
-from django.db.models.base import ModelBase
 from django.db.models.fields.files import FieldFile
 
 logger = logging.getLogger(__name__)
 
 
-def get_file_field_names(model: ModelBase) -> List[str]:
+def get_file_field_names(model: type[models.Model]) -> list[str]:
     """
     Collect names of :class:`django.db.models.FileField` (& subclass) model fields.
     """
@@ -69,10 +67,10 @@ class DeleteFileFieldFilesMixin:
         # in case the DB deletion errors but then the file is gone?
         # Postponing that decision, as likely a number of tests will fail because they
         # run in transactions.
-        file_field_names = get_file_field_names(type(self))
+        file_field_names = get_file_field_names(type(self))  # type: ignore
         with transaction.atomic():
-            result = super().delete(*args, **kwargs)
-            transaction.on_commit(lambda: _delete_obj_files(file_field_names, self))
+            result = super().delete(*args, **kwargs)  # type: ignore
+            transaction.on_commit(lambda: _delete_obj_files(file_field_names, self))  # type: ignore
         return result
 
-    delete.alters_data = True
+    delete.alters_data = True  # type: ignore

--- a/simple_certmanager/models.py
+++ b/simple_certmanager/models.py
@@ -51,7 +51,7 @@ class Certificate(DeleteFileFieldFilesMixin, models.Model):
         verbose_name = _("certificate")
         verbose_name_plural = _("certificates")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.label or gettext("(missing label)")
 
     @property

--- a/simple_certmanager/utils.py
+++ b/simple_certmanager/utils.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
@@ -19,8 +19,19 @@ def load_pem_x509_private_key(data: bytes):
     return load_pem_private_key(data, password=None)
 
 
+def _decode(value: Union[str, bytes]) -> str:
+    # attr.value can be bytes, in which case it is must be an UTF8String or
+    # PrintableString (the latter being a subset of ASCII, thus also a subset of UTF8)
+    # See https://www.rfc-editor.org/rfc/rfc5280.txt
+    if not isinstance(value, bytes):
+        return value
+    return value.decode("utf8")
+
+
 def pretty_print_certificate_components(x509name: x509.Name) -> str:
-    bits = (f"{attr.rfc4514_attribute_name}: {attr.value}" for attr in x509name)
+    bits = (
+        f"{attr.rfc4514_attribute_name}: {_decode(attr.value)}" for attr in x509name
+    )
     return ", ".join(bits)
 
 

--- a/simple_certmanager/utils.py
+++ b/simple_certmanager/utils.py
@@ -36,7 +36,7 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
-def suppress_cryptography_errors(func: Callable[P, T]) -> Callable[P, T | None]:
+def suppress_cryptography_errors(func: Callable[P, T], /) -> Callable[P, T | None]:
     """
     Decorator to suppress exceptions thrown while processing PKI data.
     """

--- a/simple_certmanager/utils.py
+++ b/simple_certmanager/utils.py
@@ -2,6 +2,8 @@ import logging
 from functools import wraps
 from typing import Callable, ParamSpec, TypeVar
 
+from django.utils.encoding import force_str
+
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
@@ -19,18 +21,13 @@ def load_pem_x509_private_key(data: bytes):
     return load_pem_private_key(data, password=None)
 
 
-def _decode(value: str | bytes) -> str:
+def pretty_print_certificate_components(x509name: x509.Name) -> str:
     # attr.value can be bytes, in which case it is must be an UTF8String or
     # PrintableString (the latter being a subset of ASCII, thus also a subset of UTF8)
     # See https://www.rfc-editor.org/rfc/rfc5280.txt
-    if not isinstance(value, bytes):
-        return value
-    return value.decode("utf8")
-
-
-def pretty_print_certificate_components(x509name: x509.Name) -> str:
     bits = (
-        f"{attr.rfc4514_attribute_name}: {_decode(attr.value)}" for attr in x509name
+        f"{attr.rfc4514_attribute_name}: {force_str(attr.value, encoding='utf-8')}"
+        for attr in x509name
     )
     return ", ".join(bits)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     black
     flake8
     docs
+    py310-django32-mpy
+    py{310,311,312}-django{42}-mypy
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -60,3 +62,8 @@ commands=
     py.test check_sphinx.py -v \
     --tb=auto \
     {posargs}
+
+[testenv:py{310,311,312}-django{32,42}-mypy]
+extras = tests
+skipsdist = True
+commands = mypy simple_certmanager

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,8 @@ commands=
     {posargs}
 
 [testenv:py{310,311,312}-django{32,42}-mypy]
-extras = tests
+extras =
+    tests
+    testutils
 skipsdist = True
 commands = mypy simple_certmanager


### PR DESCRIPTION
This setup with tox.ini *should* make the mypy checks run after the (unit) tests for each python/django env.