### PR TITLE
:technologist: Distribute own fixtures as pytest plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ Documentation = "http://django-simple-certmanager.readthedocs.io/en/latest/"
 "Source Code" = "https://github.com/maykinmedia/django-simple-certmanager"
 Changelog = "https://github.com/maykinmedia/django-simple-certmanager/blob/main/CHANGELOG.rst"
 
+[project.entry-points.pytest11]
+simple_certmanager = "simple_certmanager.test.plugin"
+
 [project.optional-dependencies]
 # These are not the test requirements! They are extras to be installed when making use of `simple_certmanager.test`
 testutils = [

--- a/simple_certmanager/test/certificate_generation.py
+++ b/simple_certmanager/test/certificate_generation.py
@@ -1,0 +1,97 @@
+"""
+Helpers for x509 certificate generation.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    NoEncryption,
+)
+
+
+def mkcert(
+    subject: x509.Name,
+    subject_key: rsa.RSAPrivateKey,
+    issuer: x509.Certificate | None = None,
+    issuer_key: rsa.RSAPrivateKey | None = None,
+    can_issue: bool = True,
+):
+    public_key = subject_key.public_key()
+    issuer_name = issuer.subject if issuer else subject
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(timezone.now())
+        .not_valid_after(timezone.now() + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+        )
+        # required for certificate chain validation, even in leaf certificates
+        .add_extension(
+            x509.BasicConstraints(ca=can_issue, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=can_issue,
+                crl_sign=can_issue,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(public_key),
+            critical=False,
+        )
+    )
+
+    if issuer:
+        ski_ext = issuer.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
+        cert = cert.add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+                ski_ext.value
+            ),
+            critical=False,
+        )
+
+    return cert.sign(issuer_key if issuer_key else subject_key, hashes.SHA256())
+
+
+def key_to_pem(key: PrivateKeyTypes, passphrase: str = "") -> bytes:
+    """
+    Serialize a private key to PEM, optionally encrypting it.
+    """
+    # UNSURE if utf-8 is the encoding that is also used by openssl and friends
+    _passphrase = passphrase.encode("utf-8") if passphrase else None
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=(
+            BestAvailableEncryption(_passphrase) if _passphrase else NoEncryption()
+        ),
+    )
+
+
+def cert_to_pem(cert: x509.Certificate) -> bytes:
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def gen_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=0x10001, key_size=2048)

--- a/simple_certmanager/test/fixtures.py
+++ b/simple_certmanager/test/fixtures.py
@@ -1,0 +1,69 @@
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from .certificate_generation import cert_to_pem, gen_key, key_to_pem, mkcert
+
+
+@pytest.fixture(scope="session")
+def root_key() -> rsa.RSAPrivateKey:
+    "RSA key for the RootCA"
+    return gen_key()
+
+
+@pytest.fixture(scope="session")
+def root_cert(root_key) -> x509.Certificate:
+    "Certificate for the RootCA"
+    return mkcert(
+        x509.Name(
+            [
+                x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, "NL"),
+                x509.NameAttribute(x509.oid.NameOID.STATE_OR_PROVINCE_NAME, "NH"),
+                x509.NameAttribute(x509.oid.NameOID.LOCALITY_NAME, "Amsterdam"),
+                x509.NameAttribute(x509.oid.NameOID.ORGANIZATION_NAME, "Root CA"),
+                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "rootca.example.org"),
+            ]
+        ),
+        root_key,
+    )
+
+
+@pytest.fixture
+def leaf_keypair(
+    root_cert: x509.Certificate, root_key
+) -> tuple[rsa.RSAPrivateKey, bytes]:
+    """
+    A private key and valid pem encoded certificate directly issued by the Root CA
+    """
+    privkey = gen_key()
+    leaf_cert = mkcert(
+        subject=x509.Name(
+            [
+                x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, "NL"),
+                x509.NameAttribute(
+                    x509.oid.NameOID.STATE_OR_PROVINCE_NAME, "Some-State"
+                ),
+                x509.NameAttribute(
+                    x509.oid.NameOID.ORGANIZATION_NAME, "Internet Widgits Pty Ltd"
+                ),
+                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "widgits.example.org"),
+            ]
+        ),
+        subject_key=privkey,
+        issuer=root_cert,
+        issuer_key=root_key,
+        can_issue=False,
+    )
+    return privkey, cert_to_pem(leaf_cert)
+
+
+@pytest.fixture
+def encrypted_keypair(
+    leaf_keypair: tuple[rsa.RSAPrivateKey, bytes]
+) -> tuple[bytes, bytes]:
+    """
+    A private key + certificate pair where the private key is encrypted.
+    """
+    key, cert_pem = leaf_keypair
+    encrypted_private_key_pem = key_to_pem(key, passphrase="SUPERSECRET🔐")
+    return encrypted_private_key_pem, cert_pem

--- a/simple_certmanager/test/plugin.py
+++ b/simple_certmanager/test/plugin.py
@@ -1,0 +1,8 @@
+"""
+Pytest plugin.
+"""
+
+from .fixtures import encrypted_keypair  # noqa: F401
+from .fixtures import leaf_keypair  # noqa: F401
+from .fixtures import root_cert  # noqa: F401
+from .fixtures import root_key  # noqa: F401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,84 +1,9 @@
-import datetime
 from pathlib import Path
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.serialization import BestAvailableEncryption
 
-
-@pytest.fixture(scope="session")
-def root_key() -> rsa.RSAPrivateKey:
-    "RSA key for the RootCA"
-    key = gen_key()
-    # with (Path(__file__).parent / "data" / "test.key").open("rb") as f:
-    #     return serialization.load_pem_private_key(f.read(), password=None)
-    return key
-
-
-@pytest.fixture(scope="session")
-def root_cert(root_key) -> x509.Certificate:
-    "Certificate for the RootCA"
-    return mkcert(
-        x509.Name(
-            [
-                x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, "NL"),
-                x509.NameAttribute(x509.oid.NameOID.STATE_OR_PROVINCE_NAME, "NH"),
-                x509.NameAttribute(x509.oid.NameOID.LOCALITY_NAME, "Amsterdam"),
-                x509.NameAttribute(x509.oid.NameOID.ORGANIZATION_NAME, "Root CA"),
-                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "rootca.example.org"),
-            ]
-        ),
-        root_key,
-    )
-
-
-@pytest.fixture
-def leaf_keypair(
-    root_cert: x509.Certificate, root_key
-) -> tuple[rsa.RSAPrivateKey, bytes]:
-    """
-    A private key and valid pem encoded certificate directly issued by the Root CA
-    """
-    privkey = gen_key()
-    leaf_cert = mkcert(
-        subject=x509.Name(
-            [
-                x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, "NL"),
-                x509.NameAttribute(
-                    x509.oid.NameOID.STATE_OR_PROVINCE_NAME, "Some-State"
-                ),
-                x509.NameAttribute(
-                    x509.oid.NameOID.ORGANIZATION_NAME, "Internet Widgits Pty Ltd"
-                ),
-                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "widgits.example.org"),
-            ]
-        ),
-        subject_key=privkey,
-        issuer=root_cert,
-        issuer_key=root_key,
-        can_issue=False,
-    )
-    return privkey, to_pem(leaf_cert)
-
-
-@pytest.fixture
-def encrypted_keypair(
-    leaf_keypair: tuple[rsa.RSAPrivateKey, bytes]
-) -> tuple[bytes, bytes]:
-    """
-    A private key + certificate pair where the private key is encrypted.
-    """
-    key, cert_pem = leaf_keypair
-    # UNSURE if utf-8 is the encoding that is also used by openssl and friends
-    passphrase = "SUPERSECRET🔐".encode("utf-8")
-    encrypted_private_key_pem = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=BestAvailableEncryption(passphrase),
-    )
-    return encrypted_private_key_pem, cert_pem
+from simple_certmanager.test.certificate_generation import cert_to_pem, gen_key, mkcert
 
 
 @pytest.fixture
@@ -118,7 +43,7 @@ def chain_pem(root_cert: x509.Certificate, root_key) -> bytes:
         issuer_key=inter_key,
         can_issue=False,
     )
-    return b"".join(map(to_pem, [leaf_cert, intermediate_cert]))
+    return b"".join(map(cert_to_pem, [leaf_cert, intermediate_cert]))
 
 
 @pytest.fixture
@@ -161,7 +86,7 @@ def broken_chain_pem(root_cert: x509.Certificate, root_key):
         issuer_key=inter_key,
         can_issue=False,
     )
-    return b"".join(map(to_pem, [leaf_cert, intermediate_cert]))
+    return b"".join(map(cert_to_pem, [leaf_cert, intermediate_cert]))
 
 
 @pytest.fixture(scope="session")
@@ -169,7 +94,7 @@ def root_ca_path(root_cert, tmp_path_factory) -> Path:
     "A path to a temporary .pem for the Root CA"
     cert_path = tmp_path_factory.mktemp("fake_pki") / "fake_ca_cert.pem"
     with cert_path.open("wb") as f:
-        f.write(to_pem(root_cert))
+        f.write(cert_to_pem(root_cert))
     return cert_path
 
 
@@ -181,64 +106,3 @@ def temp_private_root(tmp_path, settings):
     settings.PRIVATE_MEDIA_ROOT = location
     settings.SENDFILE_ROOT = location
     return settings
-
-
-def mkcert(subject, subject_key, issuer=None, issuer_key=None, can_issue=True):
-    public_key = subject_key.public_key()
-    issuer_name = issuer.subject if issuer else subject
-    cert = (
-        x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer_name)
-        .public_key(public_key)
-        .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
-            critical=False,
-        )
-        # required for certificate chain validation, even in leaf certificates
-        .add_extension(
-            x509.BasicConstraints(ca=can_issue, path_length=None),
-            critical=True,
-        )
-        .add_extension(
-            x509.KeyUsage(
-                digital_signature=True,
-                content_commitment=False,
-                key_encipherment=True,
-                data_encipherment=False,
-                key_agreement=False,
-                key_cert_sign=can_issue,
-                crl_sign=can_issue,
-                encipher_only=False,
-                decipher_only=False,
-            ),
-            critical=True,
-        )
-        .add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(public_key),
-            critical=False,
-        )
-    )
-
-    if issuer:
-        ski_ext = issuer.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
-        cert = cert.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
-                ski_ext.value
-            ),
-            critical=False,
-        )
-
-    cert = cert.sign(issuer_key if issuer_key else subject_key, hashes.SHA256())
-    return cert
-
-
-def to_pem(cert: x509.Certificate) -> bytes:
-    return cert.public_bytes(serialization.Encoding.PEM)
-
-
-def gen_key():
-    return rsa.generate_private_key(public_exponent=0x10001, key_size=2048)


### PR DESCRIPTION
So that downstream packages/projects can also make use of these test helpers rather than having to duplicate them.