### PR TITLE
:sparkles: Made the (cryptography) certificate access public API

### DIFF
--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -25,6 +25,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
         "get_label",
         "serial_number",
         "type",
+        "valid_from",
         "expiry_date",
         "is_valid_key_pair",
     )
@@ -45,6 +46,15 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
         # alias model property to catch errors
         try:
             return obj.serial_number
+        except FileNotFoundError:
+            return _("file not found")
+
+    @admin.display(description=_("valid from"))
+    @suppress_cryptography_errors
+    def valid_from(self, obj: Certificate):
+        # alias model property to catch errors
+        try:
+            return obj.valid_from
         except FileNotFoundError:
             return _("file not found")
 


### PR DESCRIPTION
Rather than exposing every possible bit of information as a property, it makes more sense to provide a public API for loading the certificate with the cryptography package and operate on those instances.

This adds a column in the admin to display the valid-from information from the certificate too.

Needed for maykinmedia/django-digid-eherkenning#74