### PR TITLE
Allow editing an existing Signing Request & generate new CSR

### DIFF
--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -53,43 +53,35 @@ class SigningRequestAdmin(admin.ModelAdmin):
     )
     list_filter = ("organization_name", "state_or_province_name", "locality_name")
     search_fields = ("common_name", "organization_name", "locality_name")
+    fieldsets = (
+        (
+            _("Subject information"),
+            {
+                "fields": (
+                    "common_name",
+                    "organization_name",
+                    "country_name",
+                    "state_or_province_name",
+                    "locality_name",
+                    "email_address",
+                ),
+                "description": (
+                    _(
+                        "The CSR will be generated after entering"
+                        " the information and submitting the data."
+                    )
+                ),
+            },
+        ),
+        (
+            _("Signing Request (CSR)"),
+            {
+                "fields": ("csr", "should_renew_csr"),
+            },
+        ),
+    )
     readonly_fields = ("csr",)
     actions = [download_csr]
-
-    def get_fieldsets(self, request, obj=None):
-        fieldsets = (
-            (
-                _("Subject information"),
-                {
-                    "fields": (
-                        "common_name",
-                        "organization_name",
-                        "country_name",
-                        "state_or_province_name",
-                        "locality_name",
-                        "email_address",
-                    ),
-                    "description": (
-                        _(
-                            "The CSR will be generated after entering"
-                            " the information and submitting the data."
-                        )
-                    ),
-                },
-            ),
-            (
-                _("Signing Request (CSR)"),
-                {
-                    "fields": ("csr",),
-                },
-            ),
-        )
-
-        if obj:  # If the singing request is being edited
-            # Add the "Regenerate CSR" checkbox to Subject information fieldset
-            fieldsets[0][1]["fields"] += ("should_renew_csr",)
-
-        return fieldsets
 
     def response_post_save_add(self, request, obj, post_url_continue=None):
         return HttpResponseRedirect(

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -24,7 +24,16 @@ def test_creating_signing_request_without_common_name_fails():
 
 
 @pytest.mark.django_db
-def test_admin_create_signing_request(admin_client, db):
+def test_admin_can_load_add_page(admin_client):
+    add_url = reverse("admin:simple_certmanager_signingrequest_add")
+
+    response = admin_client.get(add_url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_create_signing_request(admin_client):
     add_url = reverse("admin:simple_certmanager_signingrequest_add")
 
     data = {

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -162,3 +162,73 @@ def test_download_csr_multiple(admin_client):
             assert csr.subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[
                 0
             ].value in ["NL", "FR"]
+
+
+@pytest.mark.django_db
+def test_admin_save_existing_csr_should_renew(admin_client):
+    signing_request = SigningRequest.objects.create(
+        common_name="test.com",
+        country_name="US",
+        organization_name="Test Org",
+        state_or_province_name="Test State",
+        email_address="test@test.com",
+    )
+
+    orginal_csr = signing_request.csr
+    original_pk = signing_request.private_key
+
+    url = reverse(
+        "admin:simple_certmanager_signingrequest_change", args=[signing_request.pk]
+    )
+    response = admin_client.post(
+        url,
+        {
+            "common_name": "test.com",
+            "country_name": "US",
+            "organization_name": "Test Org",
+            "state_or_province_name": "Test State",
+            "email_address": "test@test.com",
+            "should_renew_csr": True,
+        },
+    )
+
+    assert response.status_code == 302
+    signing_request.refresh_from_db()
+    # CSR and PK should be regenerated
+    assert signing_request.csr != orginal_csr
+    assert signing_request.private_key != original_pk
+
+
+@pytest.mark.django_db
+def test_admin_save_existing_csr_should_not_renew(admin_client):
+    signing_request = SigningRequest.objects.create(
+        common_name="test.com",
+        country_name="US",
+        organization_name="Test Org",
+        state_or_province_name="Test State",
+        email_address="test@test.com",
+    )
+
+    original_csr = signing_request.csr
+    original_pk = signing_request.private_key
+
+    url = reverse(
+        "admin:simple_certmanager_signingrequest_change", args=[signing_request.pk]
+    )
+    response = admin_client.post(
+        url,
+        {
+            "common_name": "test.com",
+            "country_name": "US",
+            "organization_name": "Test Org",
+            "state_or_province_name": "Test State",
+            "email_address": "test@test.com",
+            "should_renew_csr": False,
+        },
+    )
+
+    assert response.status_code == 302
+    signing_request.refresh_from_db()
+    # CSR and PK should not be regenerated
+    assert signing_request.csr == original_csr
+    assert signing_request.private_key == original_pk


### PR DESCRIPTION
Closes https://github.com/maykinmedia/django-simple-certmanager/issues/41

- Regenerate the CSR / PK from the Subject Information
- Added a boolean field to trigger the regeneration of the CSR
- Updated the SigningRequest model to make the CSR and PK fields editable.
- Admin_client tests