### PR TITLE
🔒️ Removing private key when certificate has been verified and uploaded

### DIFF
--- a/simple_certmanager/models.py
+++ b/simple_certmanager/models.py
@@ -92,6 +92,7 @@ class SigningRequest(models.Model):
         created_certificate.save()
         # Link the certificate to the signing request
         self.public_certificate = created_certificate
+        self.private_key = ""
         self.save()
         return created_certificate
 


### PR DESCRIPTION
Closes #45 

For security purposes, it's better to remove the private key from the signing request instance as it is now store encrypted on the client system. 

I have based this branch on #48 