### PR TITLE
:children_crossing: [#54] zero pad serial number sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ tests = [
     "black",
     "flake8",
     "freezegun",
+    "hypothesis",
 ]
 type-checking = [
     "django-stubs[compatible-mypy]",

--- a/simple_certmanager/models.py
+++ b/simple_certmanager/models.py
@@ -16,7 +16,11 @@ from simple_certmanager.csr_generation import generate_csr, generate_private_key
 
 from .constants import CertificateTypes
 from .mixins import DeleteFileFieldFilesMixin
-from .utils import load_pem_x509_private_key, pretty_print_certificate_components
+from .utils import (
+    load_pem_x509_private_key,
+    pretty_print_certificate_components,
+    pretty_print_serial_number,
+)
 from .validators import PrivateKeyValidator, PublicCertValidator
 
 
@@ -177,10 +181,7 @@ class Certificate(DeleteFileFieldFilesMixin, models.Model):
 
     @property
     def serial_number(self) -> str:
-        x509sn = self.certificate.serial_number
-        sn = hex(x509sn)[2:].upper()
-        bytes = (sn[i : i + 2] for i in range(0, len(sn), 2))
-        return ":".join(bytes)
+        return pretty_print_serial_number(self.certificate.serial_number)
 
     def is_valid_key_pair(self) -> None | bool:
         if not self.private_key:

--- a/simple_certmanager/test/fixtures.py
+++ b/simple_certmanager/test/fixtures.py
@@ -59,7 +59,7 @@ def leaf_keypair(
 
 @pytest.fixture
 def encrypted_keypair(
-    leaf_keypair: tuple[rsa.RSAPrivateKey, bytes]
+    leaf_keypair: tuple[rsa.RSAPrivateKey, bytes],
 ) -> tuple[bytes, bytes]:
     """
     A private key + certificate pair where the private key is encrypted.

--- a/simple_certmanager/utils.py
+++ b/simple_certmanager/utils.py
@@ -75,6 +75,15 @@ def pretty_print_certificate_components(x509name: x509.Name) -> str:
     return ", ".join(bits)
 
 
+def pretty_print_serial_number(x509sn: int):
+    num_bytes = (x509sn.bit_length() + 7) // 8
+    byte_values = x509sn.to_bytes(
+        num_bytes or 1,  # handle 0, e.g. b'' -> b'\x00'
+        byteorder="big",
+    )
+    return ":".join(f"{b:02X}" for b in byte_values)
+
+
 T = TypeVar("T")
 P = ParamSpec("P")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import re
+
+import pytest
+from hypothesis import given, strategies as st
+
+from simple_certmanager.utils import pretty_print_serial_number
+
+
+@pytest.mark.parametrize(
+    "serial_number,expected",
+    [
+        # Single byte, with padding
+        (0x0, "00"),
+        (0x1, "01"),
+        (0xA, "0A"),
+        (0xF, "0F"),
+        # single byte, no padding
+        (0x10, "10"),
+        (0xFF, "FF"),
+        # Multi-byte with values needing zero padding
+        (0x0A0B1C0D0E0F, "0A:0B:1C:0D:0E:0F"),
+        (0x010203, "01:02:03"),
+        # Multi-byte without zero padding needed (all bytes >= 0x10)
+        (0x102030, "10:20:30"),
+        (0xABCDEF, "AB:CD:EF"),
+        # Typical certificate size (128 bits)
+        (
+            0x70E229359BC842EBF88CEC05CD5526FEC426D6DF,
+            "70:E2:29:35:9B:C8:42:EB:F8:8C:EC:05:CD:55:26:FE:C4:26:D6:DF",
+        ),
+    ],
+)
+def test_pretty_print_serial_number(serial_number, expected):
+    result = pretty_print_serial_number(serial_number)
+    assert result == expected
+
+
+SERIAL_NUMBER_PATTERN = re.compile(r"[0-9A-F]{2}(?::[0-9A-F]{2})*")
+"""Regex pattern for validating colon-separated hex byte pairs"""
+
+
+@given(st.integers(min_value=0))
+def test_pretty_print_result_is_well_formed_and_reversible(serial_number):
+    result = pretty_print_serial_number(serial_number)
+
+    reversed_serial_number = int("".join(result.split(":")), base=16)
+    assert (
+        reversed_serial_number == serial_number
+    ), f"Reversed number {reversed_serial_number} does not match input {serial_number}"
+
+    assert SERIAL_NUMBER_PATTERN.match(
+        result
+    ), f"{result} does not match expected format of colon-separated hex byte pairs"


### PR DESCRIPTION
Most certificate viewers zero pad the hex values of the ":" separated serial number bytes, but we do not. This makes it needlessly hard to compare serial numbers, and also ensures we get fixed length serial numbers.