### PR TITLE
Assorted admin quality-of-life improvements

### DIFF
--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -1,3 +1,4 @@
+import datetime
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -7,13 +8,18 @@ from django.shortcuts import get_object_or_404
 from django.urls import path, reverse
 from django.utils.html import format_html
 from django.utils.text import slugify
+from django.utils.timesince import timesince, timeuntil
 from django.utils.translation import gettext_lazy as _
 
 from privates.admin import PrivateMediaMixin
 
 from .forms import CertificateAdminForm, SigningRequestAdminForm
 from .models import Certificate, SigningRequest
-from .utils import suppress_cryptography_errors
+from .utils import (
+    PrivateKeyError,
+    file_not_found_fallback,
+    suppress_cryptography_errors,
+)
 
 
 def download_csr_action(modeladmin, request, queryset):
@@ -169,22 +175,41 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
     fields = (
         "label",
         "serial_number",
+        "issuer",
+        "subject",
+        "not_valid_before",
+        "not_valid_before_relative",
+        "not_valid_after",
+        "not_valid_after_relative",
+        "is_in_validity_period",
         "type",
         "public_certificate",
         "private_key",
         "private_key_passphrase",
+        "is_valid_key_pair",
     )
     list_display = (
         "get_label",
         "serial_number",
         "type",
-        "valid_from",
-        "expiry_date",
+        "not_valid_before",
+        "not_valid_after",
+        "is_in_validity_period",
         "is_valid_key_pair",
     )
     list_filter = ("type",)
     search_fields = ("label", "type")
-    readonly_fields = ("serial_number",)
+    readonly_fields = (
+        "serial_number",
+        "issuer",
+        "subject",
+        "not_valid_before",
+        "not_valid_before_relative",
+        "not_valid_after",
+        "not_valid_after_relative",
+        "is_in_validity_period",
+        "is_valid_key_pair",
+    )
 
     private_media_fields = ("public_certificate", "private_key")
     private_media_no_download_fields = ("private_key",)
@@ -195,36 +220,53 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
 
     @admin.display(description=_("serial number"))
     @suppress_cryptography_errors
+    @file_not_found_fallback(_("file not found"))
     def serial_number(self, obj: Certificate):
-        # alias model property to catch errors
-        try:
-            return obj.serial_number
-        except FileNotFoundError:
-            return _("file not found")
+        return obj.serial_number
 
-    @admin.display(description=_("valid from"))
+    @admin.display(description=_("not valid before"))
     @suppress_cryptography_errors
-    def valid_from(self, obj: Certificate):
-        # alias model property to catch errors
-        try:
-            return obj.valid_from
-        except FileNotFoundError:
-            return _("file not found")
+    @file_not_found_fallback(_("file not found"))
+    def not_valid_before(self, obj: Certificate):
+        return obj.not_valid_before
 
-    @admin.display(description=_("expiry date"))
+    @admin.display(description=_("not valid after"))
     @suppress_cryptography_errors
-    def expiry_date(self, obj: Certificate):
-        # alias model property to catch errors
-        try:
-            return obj.expiry_date
-        except FileNotFoundError:
-            return _("file not found")
+    @file_not_found_fallback(_("file not found"))
+    def not_valid_after(self, obj: Certificate):
+        return obj.not_valid_after
+
+    def _relative_time(self, dt: datetime.datetime) -> str:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if dt > now:
+            return _("in {until}").format(until=timeuntil(dt))
+
+        return _("{since} ago").format(since=timesince(dt))
+
+    @admin.display(description=_("not valid before (relative)"))
+    @suppress_cryptography_errors
+    @file_not_found_fallback(_("file not found"))
+    def not_valid_before_relative(self, obj: Certificate):
+        return self._relative_time(obj.not_valid_before)
+
+    @admin.display(description=_("not valid after (relative)"))
+    @suppress_cryptography_errors
+    @file_not_found_fallback(_("file not found"))
+    def not_valid_after_relative(self, obj: Certificate):
+        return self._relative_time(obj.not_valid_after)
+
+    @admin.display(description=_("within validity period"), boolean=True)
+    @suppress_cryptography_errors
+    @file_not_found_fallback(None)
+    def is_in_validity_period(self, obj: Certificate) -> bool | None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return obj.not_valid_before <= now <= obj.not_valid_after
 
     @admin.display(description=_("valid key pair"), boolean=True)
     @suppress_cryptography_errors
+    @file_not_found_fallback(None)
     def is_valid_key_pair(self, obj: Certificate) -> bool | None:
-        # alias model property to catch errors
         try:
             return obj.is_valid_key_pair()
-        except FileNotFoundError:
+        except PrivateKeyError:
             return None

--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -11,6 +11,7 @@ from django.utils.text import slugify
 from django.utils.timesince import timesince, timeuntil
 from django.utils.translation import gettext_lazy as _
 
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from privates.admin import PrivateMediaMixin
 
 from .forms import CertificateAdminForm, SigningRequestAdminForm
@@ -184,6 +185,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
         "is_in_validity_period",
         "type",
         "public_certificate",
+        "public_key",
         "private_key",
         "private_key_passphrase",
         "is_valid_key_pair",
@@ -208,6 +210,7 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
         "not_valid_after",
         "not_valid_after_relative",
         "is_in_validity_period",
+        "public_key",
         "is_valid_key_pair",
     )
 
@@ -261,6 +264,18 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
     def is_in_validity_period(self, obj: Certificate) -> bool | None:
         now = datetime.datetime.now(datetime.timezone.utc)
         return obj.not_valid_before <= now <= obj.not_valid_after
+
+    @admin.display(description=_("public key"))
+    @suppress_cryptography_errors
+    @file_not_found_fallback(_("file not found"))
+    def public_key(self, obj: Certificate):
+        if not obj.public_certificate:
+            return None
+
+        pem = obj.certificate.public_key().public_bytes(
+            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+        )
+        return format_html("<pre>{}</pre>", pem.decode("ascii"))
 
     @admin.display(description=_("valid key pair"), boolean=True)
     @suppress_cryptography_errors

--- a/simple_certmanager/admin.py
+++ b/simple_certmanager/admin.py
@@ -173,22 +173,54 @@ class CertificateAdmin(PrivateMediaMixin, admin.ModelAdmin):
     model: type[Certificate]
     form = CertificateAdminForm
 
-    fields = (
-        "label",
-        "serial_number",
-        "issuer",
-        "subject",
-        "not_valid_before",
-        "not_valid_before_relative",
-        "not_valid_after",
-        "not_valid_after_relative",
-        "is_in_validity_period",
-        "type",
-        "public_certificate",
-        "public_key",
-        "private_key",
-        "private_key_passphrase",
-        "is_valid_key_pair",
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": ("label", "type"),
+            },
+        ),
+        (
+            _("Certificate identity"),
+            {
+                "fields": (
+                    "serial_number",
+                    "issuer",
+                    "subject",
+                ),
+            },
+        ),
+        (
+            _("Validity"),
+            {
+                "fields": (
+                    "not_valid_before",
+                    "not_valid_before_relative",
+                    "not_valid_after",
+                    "not_valid_after_relative",
+                    "is_in_validity_period",
+                ),
+            },
+        ),
+        (
+            _("Certificate and public key"),
+            {
+                "fields": (
+                    "public_certificate",
+                    "public_key",
+                ),
+            },
+        ),
+        (
+            _("Private key"),
+            {
+                "fields": (
+                    "private_key",
+                    "private_key_passphrase",
+                    "is_valid_key_pair",
+                ),
+            },
+        ),
     )
     list_display = (
         "get_label",

--- a/simple_certmanager/models.py
+++ b/simple_certmanager/models.py
@@ -160,13 +160,13 @@ class Certificate(DeleteFileFieldFilesMixin, models.Model):
         return self._private_key_obj
 
     @property
-    def valid_from(self) -> datetime:
+    def not_valid_before(self) -> datetime:
         # TODO: should probably be stored in a DB column after saving the file so
         # we can query on it to report (nearly) expired certificates.
         return self.certificate.not_valid_before_utc
 
     @property
-    def expiry_date(self) -> datetime:
+    def not_valid_after(self) -> datetime:
         # TODO: should probably be stored in a DB column after saving the file so
         # we can query on it to report (nearly) expired certificates.
         return self.certificate.not_valid_after_utc

--- a/simple_certmanager/test/certificate_generation.py
+++ b/simple_certmanager/test/certificate_generation.py
@@ -22,6 +22,8 @@ def mkcert(
     issuer: x509.Certificate | None = None,
     issuer_key: rsa.RSAPrivateKey | None = None,
     can_issue: bool = True,
+    not_valid_before: datetime.datetime | None = None,
+    not_valid_after: datetime.datetime | None = None,
 ):
     public_key = subject_key.public_key()
     issuer_name = issuer.subject if issuer else subject
@@ -31,8 +33,8 @@ def mkcert(
         .issuer_name(issuer_name)
         .public_key(public_key)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(timezone.now())
-        .not_valid_after(timezone.now() + datetime.timedelta(days=1))
+        .not_valid_before(not_valid_before or timezone.now())
+        .not_valid_after(not_valid_after or timezone.now() + datetime.timedelta(days=1))
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName("localhost")]),
             critical=False,

--- a/simple_certmanager/utils.py
+++ b/simple_certmanager/utils.py
@@ -88,6 +88,24 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
+def file_not_found_fallback(fallback):
+    """
+    Decorator that catches ``FileNotFoundError`` and returns ``fallback`` instead.
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs):
+            try:
+                return func(*args, **kwargs)
+            except FileNotFoundError:
+                return fallback
+
+        return wrapper
+
+    return decorator
+
+
 def suppress_cryptography_errors(func: Callable[P, T], /) -> Callable[P, T | None]:
     """
     Decorator to suppress exceptions thrown while processing PKI data.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from io import BytesIO
 from pathlib import Path
@@ -5,16 +6,25 @@ from pathlib import Path
 from django.core.files import File
 from django.test import Client
 from django.urls import reverse
+from django.utils import timezone
+from django.utils.timesince import timesince, timeuntil
 from django.utils.translation import gettext_lazy as _
 
 import pytest
+from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from freezegun import freeze_time
 from pyquery import PyQuery as pq
 from pytest_django.asserts import assertContains
 
 from simple_certmanager.constants import CertificateTypes
 from simple_certmanager.models import Certificate
+from simple_certmanager.test.certificate_generation import (
+    cert_to_pem,
+    gen_key,
+    mkcert,
+)
 from simple_certmanager.utils import decrypted_key_to_pem
 
 TEST_FILES = Path(__file__).parent / "data"
@@ -130,7 +140,7 @@ def test_list_view_invalid_private_key(temp_private_root, admin_client, caplog):
     assert caplog.records[0].levelname == "WARNING"
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(strict=False)
 def test_detail_view_invalid_public_cert(temp_private_root, admin_client, caplog):
     """Assert that `change_view` works if DB contains a corrupted public cert
 
@@ -176,7 +186,11 @@ def test_detail_view_invalid_private_key(temp_private_root, admin_client, caplog
     response = admin_client.get(url)
 
     assert response.status_code == 200
-    assert caplog.records == []
+    assert (
+        caplog.records[0].message
+        == "Suppressed exception while attempting to process PKI data"
+    )
+    assert caplog.records[0].levelname == "WARNING"
 
 
 def test_upload_keypair_with_encrypted_key(
@@ -281,3 +295,90 @@ def test_upload_keypair_not_encrypted_with_passphrase(
         response,
         _("The private key is not encrypted, a passphrase is not required."),
     )
+
+
+def test_add_view_no_certificate_loads(admin_client):
+    url = reverse("admin:simple_certmanager_certificate_add")
+    response = admin_client.get(url)
+    assert response.status_code == 200
+
+
+def test_detail_view_shows_relative_time_and_validity(
+    temp_private_root, admin_client, root_cert, root_key
+):
+    frozen_now = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    not_valid_before = frozen_now - datetime.timedelta(days=5)
+    valid_until = frozen_now + datetime.timedelta(days=30)
+    privkey = gen_key()
+    cert_pem = cert_to_pem(
+        mkcert(
+            subject=x509.Name(
+                [x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "test.example.org")]
+            ),
+            subject_key=privkey,
+            issuer=root_cert,
+            issuer_key=root_key,
+            not_valid_before=not_valid_before,
+            not_valid_after=valid_until,
+        )
+    )
+    certificate = Certificate.objects.create(
+        label="Test certificate",
+        type=CertificateTypes.cert_only,
+        public_certificate=File(BytesIO(cert_pem), name="cert.pem"),
+    )
+    url = reverse("admin:simple_certmanager_certificate_change", args=(certificate.pk,))
+
+    with freeze_time(frozen_now):
+        response = admin_client.get(url)
+
+    assert response.status_code == 200
+    assertContains(response, f"{timesince(not_valid_before, now=frozen_now)} ago")
+    assertContains(response, f"in {timeuntil(valid_until, now=frozen_now)}")
+    doc = pq(response.content)
+    assert doc('.field-is_in_validity_period img[alt="True"]').length == 1
+
+
+def test_detail_view_serial_number_displayed(
+    temp_private_root, admin_client, leaf_keypair
+):
+    _key, cert_pem = leaf_keypair
+    certificate = Certificate.objects.create(
+        label="Test certificate",
+        type=CertificateTypes.cert_only,
+        public_certificate=File(BytesIO(cert_pem), name="cert.pem"),
+    )
+    url = reverse("admin:simple_certmanager_certificate_change", args=(certificate.pk,))
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    assertContains(response, certificate.serial_number)
+
+
+def test_is_in_validity_period_false_for_expired_cert(
+    temp_private_root, admin_client, root_cert, root_key
+):
+    privkey = gen_key()
+    expired_cert = mkcert(
+        subject=x509.Name(
+            [x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "expired.example.org")]
+        ),
+        subject_key=privkey,
+        issuer=root_cert,
+        issuer_key=root_key,
+        not_valid_before=timezone.now() - datetime.timedelta(days=2),
+        not_valid_after=timezone.now() - datetime.timedelta(days=1),
+    )
+    certificate = Certificate.objects.create(
+        label="Expired certificate",
+        type=CertificateTypes.cert_only,
+        public_certificate=File(BytesIO(cert_to_pem(expired_cert)), name="cert.pem"),
+    )
+    url = reverse("admin:simple_certmanager_certificate_change", args=(certificate.pk,))
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    doc = pq(response.content)
+    assert doc('.field-is_in_validity_period img[alt="False"]').length == 1

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import re
 from io import BytesIO
 from pathlib import Path
 
@@ -354,6 +355,29 @@ def test_detail_view_serial_number_displayed(
 
     assert response.status_code == 200
     assertContains(response, certificate.serial_number)
+
+
+def test_detail_view_public_key_shown_as_pre(
+    temp_private_root, admin_client, leaf_keypair
+):
+    _key, cert_pem = leaf_keypair
+    certificate = Certificate.objects.create(
+        label="Test certificate",
+        type=CertificateTypes.cert_only,
+        public_certificate=File(BytesIO(cert_pem), name="cert.pem"),
+    )
+    url = reverse("admin:simple_certmanager_certificate_change", args=(certificate.pk,))
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    doc = pq(response.content)
+    pre = doc(".field-public_key pre")
+    assert pre.length == 1
+    assert re.match(
+        r"-----BEGIN PUBLIC KEY-----[\s]+[A-Za-z0-9+/=\s]+-----END PUBLIC KEY-----",
+        pre.text(),
+    )
 
 
 def test_is_in_validity_period_false_for_expired_cert(

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -48,7 +48,7 @@ class CertificateTests(TestCase):
             )
 
         self.assertEqual(
-            certificate.expiry_date,
+            certificate.not_valid_after,
             datetime(2025, 9, 18, 14, 3, 39, tzinfo=timezone.utc),
         )
         self.assertEqual(

--- a/tox.ini
+++ b/tox.ini
@@ -68,5 +68,8 @@ extras =
     tests
     testutils
     type-checking
+deps =
+    django32: django-stubs[compatible-mypy]~=4.2.0
+    django42: django-stubs[compatible-mypy]~=5.1.0
 skipsdist = True
 commands = mypy simple_certmanager


### PR DESCRIPTION
I find myself often having to download the cert files and look up specific fields, as it's sometimes a bit hard to tell them apart in the list. This will allow for some quicker lookups of key attributes from within the admin.

<img width="822" height="1428" alt="Screen Shot 2026-03-31 at 15 51 14" src="https://github.com/user-attachments/assets/8371be39-53d5-47ea-a12f-58d9711b2b2e" />
<img width="822" height="1600" alt="Screen Shot 2026-03-31 at 15 50 45" src="https://github.com/user-attachments/assets/5e33d6d8-4cd8-4bc4-9a5a-dad850736d4e" />
