### PR TITLE
:boom: Update supported Python and Django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -36,7 +36,7 @@ jobs:
           DJANGO: ${{ matrix.django }}
 
       - name: Publish coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -51,8 +51,8 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: 'pyproject.toml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
-        django: ['3.2', '4.2']
-        exclude:
-          - python: '3.11'
-            django: '3.2'
-          - python: '3.12'
-            django: '3.2'
+        python: ['3.12', '3.13', '3.14']
+        django: ['5.2', '6.0']
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 
@@ -59,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version-file: 'pyproject.toml'
 
       - name: Build wheel
         run: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version-file: 'pyproject.toml'
       - name: Install dependencies
         run: pip install tox
       - run: tox

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         toxenv: [isort, black, flake8, docs]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: 'pyproject.toml'
       - name: Install dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 python:
   install:

--- a/README.rst
+++ b/README.rst
@@ -27,13 +27,6 @@ Features
 Installation
 ============
 
-Requirements
-------------
-
-* Python 3.10 or above
-* Django 3.2 or newer
-
-
 Install
 -------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,12 +1,6 @@
 Quickstart
 ==========
 
-Requirements
-------------
-
-* Python 3.10 or newer
-* Django 3.2 or newer
-
 Installation
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,20 +15,20 @@ keywords = ["django", "certificate", "security"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
-    "django>=3.2",
+    "django>=5.2",
     "django-privates>=1.5",
     "cryptography>=35.0.0",
 ]

--- a/simple_certmanager/migrations/0003_signingrequest_and_more.py
+++ b/simple_certmanager/migrations/0003_signingrequest_and_more.py
@@ -82,7 +82,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="signingrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         models.Q(("csr", ""), ("private_key", "")),
                         models.Q(

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,23 @@
 [tox]
 envlist =
-    py310-django32
-    py{310,311,312}-django{42}
+    py{312,313,314}-django{52,60}
+    py{312,313,314}-django{52,60}-mypy
     isort
     black
     flake8
     docs
-    py310-django32-mpy
-    py{310,311,312}-django{42}-mypy
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
-    4.2: django42
+    5.2: django52
+    6.0: django60
 
 [testenv]
 setenv =
@@ -29,8 +27,8 @@ extras =
     tests
     coverage
 deps =
-  django32: Django~=3.2.0
-  django42: Django~=4.2.0
+  django52: Django~=5.2.0
+  django60: Django~=6.0.0
 commands =
   py.test tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \
@@ -63,13 +61,13 @@ commands=
     --tb=auto \
     {posargs}
 
-[testenv:py{310,311,312}-django{32,42}-mypy]
+[testenv:py{312,313,314}-django{52,60}-mypy]
 extras =
     tests
     testutils
     type-checking
 deps =
-    django32: django-stubs[compatible-mypy]~=4.2.0
-    django42: django-stubs[compatible-mypy]~=5.1.0
+    django52: django-stubs[compatible-mypy]~=5.2.0
+    django60: django-stubs[compatible-mypy]~=6.0.0
 skipsdist = True
 commands = mypy simple_certmanager


### PR DESCRIPTION
Drop end-of-life versions and extend the support matrix:

- Drop Django 3.2 (EOL April 2024), 4.2 (EOL April 2026) and Python 3.10, 3.11
- Add Django 5.2 (LTS), 6.0 and Python 3.13, 3.14
- Update pyproject.toml classifiers, requires-python (>=3.12) and django>= constraint
- Update tox envlist, deps, gh-actions mapping and mypy stubs
- Update CI matrix, .readthedocs.yaml and README requirements accordingly
- Use Python 3.13 for single-version jobs (publish, linting, docs)

Also: bump the various github actions that depend on Node 20 address GHA deprecation warnings, and pin them to a specific sha for security.
