### PR TITLE
:memo: update cl entry for 3.0.0 to highlight previously omitted breaking change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Changelog
 
 * Dropped support for Python 3.10 and 3.11
 * Dropped support for Django 3.2 (EOL April 2024) and 4.2 (EOL April 2026)
+* Two properties on the ``Certificate`` model have been renamed: ``valid_from`` to
+  ``not_valid_before`` and ``expiry_date`` to ``not_valid_after``
 
 **New supported versions**
 


### PR DESCRIPTION
I erroneously but culpably forgot to flag this in the changelog. We won't amend the release tag, but future readers of the CL should be aware. Flagged by @sergei-maertens 